### PR TITLE
fix: B2B uac parse Signal 0

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -758,7 +758,7 @@ Duration=${payload.duration} `
         }
       }
       else if (dlg.type === 'uac' && ['application/dtmf-relay', 'application/dtmf'].includes(contentType)) {
-        const arr = /Signal=\s*([1-9#*])/.exec(req.body);
+        const arr = /Signal=\s*([0-9#*])/.exec(req.body);
         if (!arr) {
           this.logger.info({body: req.body}, '_onInfo: invalid INFO dtmf request');
           throw new Error(`_onInfo: no dtmf in body for ${contentType}`);


### PR DESCRIPTION
I'm not able to create uas-info.xml for UAS to send SIP INFO to test the code change. But I do test locally for regex extract:

const test = "Signal=0#\r\nDuration=50"
const arr = /Signal=\s*([0-9#*])/.exec(test);
const arr2 = /Duration=\s*(\d+)/.exec(test);
console.log(arr[1]);
console.log(arr2[1]);

Tested with 
Signal=0#\r\nDuration=50
Signal=0\r\nDuration=150
