### PR TITLE
Stop SRS Client if running on destruction

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -519,6 +519,11 @@ class CallSession extends Emitter {
         dlg.other = null;
         other.other = null;
 
+        if (this.srsClient) {
+          this.srsClient.stop();
+          this.srsClient = null;
+        }
+
         this.logger.info(`call ended with normal termination, there are ${this.activeCallIds.size} active`);
 
         this.srf.endSession(this.req);


### PR DESCRIPTION
On outbound calls I wasn't seeing a BYE sent to the SIPREC server when the call finished and the dialog was torn down.

I've added a few lines to stop the SRS client on destruction, matching the code in sbc-inbound.