### PR TITLE
Fix: Feature server REFER

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -910,8 +910,10 @@ Duration=${payload.duration} `
 
       const uac = await this.srf.createUAC(referTo.uri, {localSdp: dlg.local.sdp, headers});
       this.uas = uac;
+      uac.type = 'uas';
       uac.other = this.uac;
       this.uac.other = uac;
+      uac.on('info', this._onInfo.bind(this, uac));
       uac.on('modify', this._onReinvite.bind(this, uac));
       uac.on('refer', this._onFeatureServerTransfer.bind(this, uac));
       uac.on('destroy', () => {

--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -923,24 +923,15 @@ Duration=${payload.duration} `
         this.srf.endSession(this.req);
       });
 
-      let opts = {
+      const opts = {
         ...this.rtpEngineOpts.common,
         'from-tag': this.rtpEngineOpts.uas.tag,
-        sdp: uac.remote.sdp
+        sdp: uac.remote.sdp,
+        flags: ['port latching']
       };
-      let response = await this.offer(opts);
+      const response = await this.offer(opts);
       if ('ok' !== response.result) {
         throw new Error(`_onFeatureServerTransfer: rtpengine offer failed: ${JSON.stringify(response)}`);
-      }
-      opts = {
-        ...this.rtpEngineOpts.common,
-        'from-tag': this.rtpEngineOpts.uas.tag,
-        'to-tag': this.rtpEngineOpts.uac.tag,
-        sdp: await uac.other.modify(response.sdp)
-      };
-      response = await this.answer(opts);
-      if ('ok' !== response.result) {
-        throw new Error(`_onFeatureServerTransfer: rtpengine answer failed: ${JSON.stringify(response)}`);
       }
       dlg.destroy().catch(() => {});
       this.logger.info('successfully moved call to new feature server');

--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -907,35 +907,45 @@ Duration=${payload.duration} `
         ...(req.has('X-Retain-Call-Sid') && {'X-Retain-Call-Sid': req.get('X-Retain-Call-Sid')}),
         ...(req.has('X-Account-Sid') && {'X-Account-Sid': req.get('X-Account-Sid')})
       };
-      const dlg = await this.srf.createUAC(referTo.uri, {localSdp: dlg.local.sdp, headers});
-      this.uas = dlg;
-      this.uas.other = this.uac;
-      this.uac.other = this.uas;
-      this.uas.on('modify', this._onReinvite.bind(this, this.uas));
-      this.uas.on('refer', this._onFeatureServerTransfer.bind(this, this.uas));
-      this.uas.on('destroy', () => {
+
+      const uac = await this.srf.createUAC(referTo.uri, {localSdp: dlg.local.sdp, headers});
+      this.uas = uac;
+      uac.other = this.uac;
+      this.uac.other = uac;
+      uac.on('modify', this._onReinvite.bind(this, uac));
+      uac.on('refer', this._onFeatureServerTransfer.bind(this, uac));
+      uac.on('destroy', () => {
         this.logger.info('call ended with normal termination');
         this.rtpEngineResource.destroy();
         this.activeCallIds.delete(this.req.get('Call-ID'));
         if (this.activeCallIds.size === 0) this.idleEmitter.emit('idle');
-        this.uas.other.destroy();
+        uac.other.destroy();
         this.srf.endSession(this.req);
       });
 
-      // modify rtpengine to stream to new feature server
-      let response = await this.offer(Object.assign(this.rtpEngineOpts.offer, {sdp: this.uas.remote.sdp}));
+      let opts = {
+        ...this.rtpEngineOpts.common,
+        'from-tag': this.rtpEngineOpts.uas.tag,
+        sdp: uac.remote.sdp
+      };
+      let response = await this.offer(opts);
       if ('ok' !== response.result) {
-        throw new Error(`_onReinvite: rtpengine failed: offer: ${JSON.stringify(response)}`);
+        throw new Error(`_onFeatureServerTransfer: rtpengine offer failed: ${JSON.stringify(response)}`);
       }
-      const sdp = await this.uas.other.modify(response.sdp);
-      const opts = Object.assign({sdp, 'to-tag': res.getParsedHeader('To').params.tag},
-        this.rtpEngineOpts.answer);
+      opts = {
+        ...this.rtpEngineOpts.common,
+        'from-tag': this.rtpEngineOpts.uas.tag,
+        'to-tag': this.rtpEngineOpts.uac.tag,
+        sdp: await uac.other.modify(response.sdp)
+      };
       response = await this.answer(opts);
       if ('ok' !== response.result) {
-        throw new Error(`_onReinvite: rtpengine failed: ${JSON.stringify(response)}`);
+        throw new Error(`_onFeatureServerTransfer: rtpengine answer failed: ${JSON.stringify(response)}`);
       }
+      dlg.destroy().catch(() => {});
       this.logger.info('successfully moved call to new feature server');
     } catch (err) {
+      res.send(488);
       this.logger.error(err, 'Error handling refer from feature server');
     }
   }


### PR DESCRIPTION
This addresses #89

This is mostly correcting (I think) the old code. Adding the destruction of the old dialog of the REFERing feature server and returning a 488 if things go wrong.

I've tested the best I can, I'm getting audio!

I hope re-using the `to-tag` and `from-tag` is the right thing to do when setting up the dialog/audio to the target feature server?