### PR TITLE
fix service_provider_sid undefined

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -99,6 +99,10 @@ class CallSession extends Emitter {
     this._mediaReleased = false;
   }
 
+  get service_provider_sid() {
+    return this.req.locals.service_provider_sid;
+  }
+
   get account_sid() {
     return this.req.locals.account_sid;
   }


### PR DESCRIPTION
Fix an error where service_provider_sid was undefined when trying to use this.service_provider_sid for call count.