### PR TITLE
Added a environment variable JAMBONES_OUTDIAL_TRUNK_FAILOVER to disab…

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -229,6 +229,14 @@ class CallSession extends Emitter {
           /* was a specific carrier requested */
           let voip_carrier_sid = this.req.get('X-Requested-Carrier-Sid');
           const account_sid = this.req.get('X-Account-Sid');
+          this.logger.info(`carrier requested ${voip_carrier_sid}`);
+          if (!voip_carrier_sid) {
+            if(process.env.JAMBONES_OUTDIAL_TRUNK_FAILOVER==='false') {
+              this.logger.info(`no outbound carriers found for account_sid ${account_sid}`);
+              this.res.send(603);
+              return this.srf.endSession(this.req);
+            }
+          }
           if (!voip_carrier_sid && account_sid) {
             /* search for an LCR table for this account or service provider */
             voip_carrier_sid = await this.lookupCarrierByAccountLcr(account_sid, this.req.calledNumber);
@@ -247,7 +255,7 @@ class CallSession extends Emitter {
           }
           if (!voip_carrier_sid) {
             /* no LCR/ inbound carrier for this account/SP - at this point its a random shuffle of outbound carriers */
-            voip_carrier_sid = await this.lookupOutboundCarrierForAccount(this.account_sid);
+              voip_carrier_sid = await this.lookupOutboundCarrierForAccount(this.account_sid);
           }
           if (!voip_carrier_sid) {
             /* no outbound carriers exist for this account/SP */


### PR DESCRIPTION
…le random trunk selection

Changed the way outbound trunk selection is done by checking for environment variable (default undefined) and to reject the call if no valid trunk is given on the Dial verb. 

This is done to prevent the system choosing a random trunk. 
