### PR TITLE
Support SIP over TLS | SIPS  in Contact header

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -27,9 +27,9 @@ const createBLegFromHeader = (req, teams, register_from_domain = null) => {
     host = register_from_domain;
   }
   if (from.name) {
-    return `${from.name} <sip:${user}@${host}>`;
+    return `${from.name} <${this.scheme}:${user}@${host}>`;
   }
-  return `sip:${user}@${host}`;
+  return `${this.scheme}:${user}@${host}`;
 };
 const createBLegToHeader = (req, teams) => {
   const to = req.getParsedHeader('To');
@@ -191,11 +191,12 @@ class CallSession extends Emitter {
     let encryptedMedia = false;
 
     try {
+      this.contactHeader = createBLegFromHeader(this.req, teams);
       // determine where to send the call
       debug(`connecting call: ${JSON.stringify(this.req.locals)}`);
       let headers = {
         'From': createBLegFromHeader(this.req, teams),
-        'Contact': createBLegFromHeader(this.req, teams),
+        'Contact': this.contactHeader,
         'To': createBLegToHeader(this.req, teams),
         Allow: 'INVITE, ACK, OPTIONS, CANCEL, BYE, NOTIFY, UPDATE, PRACK',
         'X-Account-Sid': this.account_sid
@@ -299,12 +300,15 @@ class CallSession extends Emitter {
               const protocol =  o.protocol?.startsWith('tls') ? 'tls' : (o.protocol || 'udp');
               const hostport = !o.port || 5060 === o.port ? o.ipv4 : `${o.ipv4}:${o.port}`;
               const prependPlus = vc.e164_leading_plus && !this.req.calledNumber.startsWith('0') ? '+' : '';
-              const transport = `transport=${protocol}`;
+              this.transport = `transport=${protocol}`;
               const useSipsScheme = protocol === 'tls' &&
                 !process.env.JAMBONES_USE_BEST_EFFORT_TLS &&
                 o.use_sips_scheme;
-              const scheme = useSipsScheme ? 'sips' : 'sip';
-              const u = `${scheme}:${prefix}${prependPlus}${calledNumber}@${hostport};${transport}`;
+
+              if (useSipsScheme) {
+                this.scheme = 'sips';
+              }
+              const u = `${this.scheme}:${prefix}${prependPlus}${calledNumber}@${hostport};${this.transport}`;
               const obj = {
                 name: vc.name,
                 diversion: vc.diversion,
@@ -436,7 +440,10 @@ class CallSession extends Emitter {
         }
         else this.logger.info(`sending INVITE to ${uri} via proxy ${proxy})`);
         try {
-          const responseHeaders = this.privateSipAddress ? {Contact: `<sip:${this.privateSipAddress}>`} : {};
+          if (this.privateSipAddress) {
+            this.contactHeader = `<${this.scheme}:${this.privateSipAddress}>`;
+          }
+          const responseHeaders = this.privateSipAddress ? {Contact: this.contactHeader} : {};
 
           const {uas, uac} = await this.srf.createB2BUA(this.req, this.res, uri, {
             proxy,
@@ -795,7 +802,12 @@ Duration=${payload.duration} `
         throw new Error(`_onReinvite: rtpengine failed: ${JSON.stringify(response)}`);
       }
       this.logger.debug({opts, sdp: response.sdp}, 'CallSession:_onReinvite: (answer) sending back upstream');
-      res.send(200, {body: response.sdp});
+      res.send(200, {
+        body: response.sdp,
+        headers: {
+          'Contact': this.contactHeader
+        }
+      });
     } catch (err) {
       res.send(err.status || 500);
       this.logger.error(err, 'Error handling reinvite');
@@ -1040,13 +1052,22 @@ Duration=${payload.duration} `
         const farEnd = parseUri(this.connectedUri);
         uri.host = farEnd.host;
         uri.port = farEnd.port;
+        this.scheme = farEnd.scheme;
 
+        if (farEnd.params?.transport) {
+          this.transport = `transport=${farEnd.params.transport}`;
+        }
+        /* TODO: we receive a lowercase 'contact' from feature-server */
+        delete customHeaders['contact'];
+
+        this.referContactHeader = `<${this.scheme}:${uri.user}@${uri.host}:${uri.port}>;${this.transport}`;
         const response = await this.uac.request({
           method: 'REFER',
           headers: {
             // Make sure the uri is protected by <> if uri is complex form
             'Refer-To': `<${stringifyUri(uri)}>`,
             'Referred-By': `<${stringifyUri(u)}>`,
+            'Contact': this.referContactHeader,
             ...customHeaders
           }
         });


### PR DESCRIPTION
- [x] Improved by: sip scheme in contact header of re-invite 200 OK should be same as in initial 200 OK
- [x] Improved by: using the same scheme of 200 OK in `Contact` header after `sip:refer`

# Success criteria

- SIP over TLS or SIPS scheme is used in the `Contact` headers of `200 OK`
- SIP over TLS or SIPS scheme is used in the `Contact` headers of `REFER`

# How to test
1. Place an outbound call via REST 
2. Within the conversation use a REFER
3. Evaluate success criteria


## Clarify: 
The `contact` header received by featuere-server is in **lowercase**

That leads to the issue that this does not overwrite the contact header accordingly but adds a second one:
```js
const response = await this.uac.request({
          method: 'REFER',
          headers: {
            // Make sure the uri is protected by <> if uri is complex form
            'Refer-To': `<${stringifyUri(uri)}>`,
            'Referred-By': `<${stringifyUri(u)}>`,
            ...customHeaders,
            'Contact': this.referContactHeader,
          }
        });

=> 
contact: <>
Contact <>
```

Or would it a better approach to send already the correct one from `feature-server` ?