### PR TITLE
fix: do not crop leading plus

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -315,13 +315,11 @@ class CallSession extends Emitter {
           if (gws.length) {
             uris = [];
             gws.forEach((o) => {
-              const calledNumber = this.req.calledNumber.startsWith('+') ?
-                this.req.calledNumber.slice(1) :
-                this.req.calledNumber;
+              const calledNumber = this.req.calledNumber;
               const prefix = vc.tech_prefix || '';
               const transport =  o.protocol?.startsWith('tls') ? 'tls' : (o.protocol || 'udp');
               const hostport = !o.port || 5060 === o.port ? o.ipv4 : `${o.ipv4}:${o.port}`;
-              const prependPlus = vc.e164_leading_plus && !this.req.calledNumber.startsWith('0') ? '+' : '';
+              const prependPlus = vc.e164_leading_plus && !(calledNumber.startsWith('+') || calledNumber.startsWith('0')) ? '+' : '';
               const scheme = transport === 'tls' && !process.env.JAMBONES_USE_BEST_EFFORT_TLS && o.use_sips_scheme ?
                 'sips' : 'sip';
               let u = `${scheme}:${prefix}${prependPlus}${calledNumber}@${hostport};transport=${transport}`;


### PR DESCRIPTION
I have no idea why the component drops the leading plus sign. This behaviour does not allow us to use the numbers with leading `+ ` as the sbc-outbound crops it and the number sends out without the plus sign.