### PR TITLE
increase dtmf volume

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -1106,11 +1106,13 @@ Duration=${payload.duration} `
           const code = arr[1];
           const arr2 = /Duration=\s*(\d+)/.exec(req.body);
           const duration = arr2 ? arr2[1] : 250;
+          const volume = 13;
           const dtmfOpts = {
             ...this.rtpEngineOpts.common,
             'from-tag': this.rtpEngineOpts.uas.tag,
             code,
-            duration
+            duration,
+            volume
           };
           const response = await this.playDTMF(dtmfOpts);
           if ('ok' !== response.result) {


### PR DESCRIPTION
https://github.com/jambonz/jambonz-feature-server/issues/1272

the volume of dtmf is very low

RFC 2833 RTP Event
RFC 2833 RTP Event
Event ID: DTMF One 1 (1)
0... .... = End of Event: False
.0.. .... = Reserved: False
..11 1111 = Volume: 63
Event Duration: 960
63 is low volume 10 is high volume

with low volume one of the client sbc is not able to capture the dtmf
for rtpegine volume
Sets the tone volume for DTMF-security modes tone, zero, DTMF, and random` in negative dB. The default is -10 dB. The highest possible volume is 0 dB and the lowest possible volume is -63 dB.