### PR TITLE
update isPrivateVoipNetwork function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -290,7 +290,7 @@ const isPrivateVoipNetwork = async(uri) => {
   if (privateNetworkCidr) {
     try {
       const matcher = new CIDRMatcher(privateNetworkCidr.split(','));
-      const arr = /sips?:.*@(.*?)(:\d+)?(;.*)$/.exec(uri);
+      const arr = /sips?:.*@(.*?)(:\d+)?(;.*)?$/.exec(uri);
       if (arr) {
         const input = arr[1];
         let addresses;


### PR DESCRIPTION
The regex was previously requiting a `;` on the end of the URI to match, so a uri such as
`sip:123@192.168.1.1;transport=udp` or even just `sip:123@192.168.1.1;` would match but `sip:123@192.168.1.1` would not and would always return false.

This makes the `;` optional