### PR TITLE
Fix/transport in contact

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -497,16 +497,19 @@ class CallSession extends Emitter {
           };
         }
         else {
+          const uri = parseUri(this.req.uri)
           hdrs = {
             ...hdrs,
             'From': createBLegFromHeader({
               logger: this.logger,
               req: this.req,
+              transport: uri.params.transport,
               ...(private_network && {host: this.privateSipAddress})
             }),
             'Contact': createBLegFromHeader({
               logger: this.logger,
               req: this.req,
+              transport: uri.params.transport,
               ...(private_network && {host: this.privateSipAddress})
             })
           };

--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -497,7 +497,7 @@ class CallSession extends Emitter {
           };
         }
         else {
-          const uri = parseUri(this.req.uri)
+          const uri = parseUri(this.req.uri);
           hdrs = {
             ...hdrs,
             'From': createBLegFromHeader({


### PR DESCRIPTION
for calls where the destination is a SIP type and the URI contains a transport param this now uses that param when creating the Contact and From headers, so the request is the same as an outgoing request via a gateway/carrier