### PR TITLE
don't strip leading + from numbers in CDR

### DIFF
--- a/lib/call-session.js
+++ b/lib/call-session.js
@@ -69,11 +69,8 @@ const initCdr = (req, invite) => {
   const {srf} = req;
   const {trace_id} = req.locals;
   const uri = parseUri(invite.uri);
-  const regex = /^\+(\d+)$/;
-  let arr = regex.exec(invite.calledNumber);
-  const to = arr ? arr[1] : invite.calledNumber;
-  arr = regex.exec(invite.callingNumber);
-  const from = arr ? arr[1] : invite.callingNumber;
+  const to = invite.calledNumber;
+  const from = invite.callingNumber;
   const applicationSid = req.get('X-Application-Sid');
 
   return {


### PR DESCRIPTION
This addresses https://github.com/jambonz/sbc-outbound/issues/219
The change ensures that the To and From being written to the Outbound Call Record are unchanged from the request.